### PR TITLE
PROXY was a better name

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,11 +1,13 @@
 :toc: macro
 = Hexboard UI
 
-A hexboard for visualizing Kubernetes pod status
+Container vizualization for link:OpenShift platformV3[http://openshift.com/]. As featured in the link:Red Hat Summit 2015 - JBoss Keynote demo[https://www.youtube.com/watch?v=wWNVpFibayA&t=26m48s]
 
 toc::[]
 
-= Run the project on an OpenShift cluster
+= Basic Setup
+
+To use a VM, follow the setup instructions from link:http://bit.ly/v3devs[this workshop]
 
 == Authentication
 [source, bash]
@@ -31,7 +33,7 @@ Create a project to house this application:
 oc new-project <project-name>
 ----
 
-Load the project from a template:
+Install and launch the project from a template:
 
 [source, bash]
 ----
@@ -54,7 +56,11 @@ Then, check the results:
 oc get builds -w
 ----
 
-Wait for the _sketchpod_ and _hexboard_ builds to complete.  Or, start the builds as needed:
+= Builds
+
+Docker image builds can be initiated by navigating to the "Builds" tab in the V3 web console. Click on the **Start Build** button for each service.
+
+You can also initiate the builds from the command line:
 
 [source, bash]
 ----
@@ -70,6 +76,7 @@ oc get pods -w
 ----
 
 = Routing
+
 In order to view the hexboard, you'll need to expose your service by setting up a Route.
 The optional `--hostname` flag allows you to create a custom route to an existing `service`:
 
@@ -132,7 +139,7 @@ To scale the number of hexagons (either up or down) run the command:
 
 [source, bash]
 ----
-oc scale rc/sketchpod --replicas=<number>
+oc scale rc/sketchpod-1 --replicas=<number>
 ----
 
 After scaling up, try submitting sketches by visiting the hexboard's bundled mobile web submission form, at `http://your-hexboard-hostname/mobile/`.
@@ -160,3 +167,14 @@ Run `gulp` in it's own terminal, providing environment variables that reference 
 ----
 PORT=8081 PROXY="localhost:1080" ACCESS_TOKEN="${ACCESS_TOKEN}" OPENSHIFT_SERVER="localhost:8443" NAMESPACE=hexboard gulp
 ----
+
+= Cleanup
+
+You can clear out everything in your existing project by running the following:
+
+[source, bash]
+----
+oc delete all --all
+----
+
+TIP: Be careful to verify that you're logged into the correct server and project before running this command!

--- a/README.adoc
+++ b/README.adoc
@@ -10,8 +10,8 @@ toc::[]
 == Authentication
 [source, bash]
 ----
-> oc login <openshift-cluster-ip>
-> oc config view
+oc login <openshift-cluster-ip>
+oc config view
 ----
 
 Take note of the OAUTH token in the `config view` for your openshift cluster and include it as needed in example commands.
@@ -20,7 +20,7 @@ Export this configuration detail to use it in the following examples as `${ACCES
 
 [source, bash]
 ----
-> export ACCESS_TOKEN="YOUR_ACCESS_TOKEN_FROM_OC_CONFIG_VIEW"
+export ACCESS_TOKEN="YOUR_ACCESS_TOKEN_FROM_OC_CONFIG_VIEW"
 ----
 
 == Create a project
@@ -28,45 +28,45 @@ Create a project to house this application:
 
 [source, bash]
 ----
-> oc new-project <project-name>
+oc new-project <project-name>
 ----
 
 Load the project from a template:
 
 [source, bash]
 ----
-> oc create -f https://raw.githubusercontent.com/2015-Middleware-Keynote/hexboard/master/app_template.json
-> oc process -v="HEXBOARD_HOST=${HEXBOARD_HOST},ACCESS_TOKEN=${ACCESS_TOKEN}" hexboard | oc create -f -
+oc create -f https://raw.githubusercontent.com/2015-Middleware-Keynote/hexboard/master/app_template.json
+oc process -v="ACCESS_TOKEN=${ACCESS_TOKEN}" hexboard | oc create -f -
 ----
 
 Or, create each service individually:
 
 [source, bash]
 ----
-> oc new-app openshift/nodejs-010-centos7~http://github.com/2015-Middleware-Keynote/sketchpod
-> oc new-app -e "HEXBOARD_HOST=${HEXBOARD_HOST},ACCESS_TOKEN=${ACCESS_TOKEN}" openshift/nodejs-010-centos7~http://github.com/2015-Middleware-Keynote/hexboard
+oc new-app openshift/nodejs-010-centos7~http://github.com/2015-Middleware-Keynote/sketchpod
+oc new-app -e "ACCESS_TOKEN=${ACCESS_TOKEN}" openshift/nodejs-010-centos7~http://github.com/2015-Middleware-Keynote/hexboard
 ----
 
 Then, check the results:
 
 [source, bash]
 ----
-> oc get builds -w
+oc get builds -w
 ----
 
 Wait for the _sketchpod_ and _hexboard_ builds to complete.  Or, start the builds as needed:
 
 [source, bash]
 ----
-> oc start-build hexboard
-> oc start-build sketchpod
+oc start-build hexboard
+oc start-build sketchpod
 ----
 
 Watch the progress:
 
 [source, bash]
 ----
-> oc get pods -w
+oc get pods -w
 ----
 
 = Routing
@@ -75,7 +75,7 @@ The optional `--hostname` flag allows you to create a custom route to an existin
 
 [source, bash]
 ----
-> oc expose se/hexboard --hostname=$HEXBOARD_HOST
+oc expose se/hexboard --hostname=<your-hexboard-hostname>
 ----
 
 This creates an external route for the service.  Make sure this route is addressable from wherever you are running your browser (an `/etc/hosts` entry in your client _may_ be required).
@@ -84,19 +84,17 @@ Excluding the `--hostname` flag should generate a default route that automatical
 
 [source, bash]
 ----
-> oc expose se/hexboard
+oc expose se/hexboard
 ----
 
 Now, try listing your existing routes:
 
 [source, bash]
 ----
-> oc get route
+oc get route
 ----
 
-NOTE: To run this application in a VM, try exposing the hexboard service at `localhost`, while setting your `HEXBOARD_HOST` config to `localhost:1080`.
-
-== Configuration
+= Configuration
 
 The service configuration is provided via environment variables. These configs can be set while loading a project from a template via the web console or via the `oc process` command.  
 
@@ -106,15 +104,7 @@ To set the **required** `ACCESS_TOKEN` config, follow the instructions in the ab
 
 [source, bash]
 ----
-> oc env dc/hexboard ACCESS_TOKEN="${ACCESS_TOKEN}"
-----
-
-This example uses the results of the `oc get route` command to update your proxy host URL info with any route info that you've established in previous `oc expose` steps.
-
-[source, bash]
-----
-> export HEXBOARD_HOST=$(oc get routes -o template -t '''{{with index .items 0}}{{.spec.host}}{{end}}''')
-> oc env dc/hexboard HEXBOARD_HOST="${HEXBOARD_HOST}"
+oc env dc/hexboard ACCESS_TOKEN="${ACCESS_TOKEN}"
 ----
 
 The number of pods in the hexboard can be controlled by setting the `HEXBOARD_SIZE` environment variable:
@@ -130,8 +120,8 @@ The number of pods in the hexboard can be controlled by setting the `HEXBOARD_SI
 
 [source, bash]
 ----
-> oc env dc/hexboard HEXBOARD_SIZE=<hexboard-size>
-> oc get pods -w
+oc env dc/hexboard HEXBOARD_SIZE=<hexboard-size>
+oc get pods -w
 ----
 
 NOTE: setting an environment variable triggers a new deployment, so watch the `oc get pods -w` output to see when the deployment is complete.
@@ -142,10 +132,10 @@ To scale the number of hexagons (either up or down) run the command:
 
 [source, bash]
 ----
-> oc scale rc/sketchpod --replicas=<number>
+oc scale rc/sketchpod --replicas=<number>
 ----
 
-After scaling up, try submitting sketches by visiting the hexboard's bundled mobile web submission form, available at: `http://${HEXBOARD_HOST}/mobile/`
+After scaling up, try submitting sketches by visiting the hexboard's bundled mobile web submission form, at `http://your-hexboard-hostname/mobile/`.
 
 = Local Development
 
@@ -159,7 +149,7 @@ After scaling up, try submitting sketches by visiting the hexboard's bundled mob
 Execute the following commands in your local clone of this repository:
 [source, bash]
 ----
-> npm install
+npm install
 ----
 
 == Run the hexboard locally
@@ -168,5 +158,5 @@ Run `gulp` in it's own terminal, providing environment variables that reference 
 
 [source, bash]
 ----
-> PORT=8081 HEXBOARD_HOST="localhost:8081" ACCESS_TOKEN="${ACCESS_TOKEN}" OPENSHIFT_SERVER="localhost:8443" NAMESPACE=hexboard gulp
+PORT=8081 PROXY="localhost:1080" ACCESS_TOKEN="${ACCESS_TOKEN}" OPENSHIFT_SERVER="localhost:8443" NAMESPACE=hexboard gulp
 ----

--- a/app_template.json
+++ b/app_template.json
@@ -306,10 +306,6 @@
                                         "value": "${HEXBOARD_SIZE}"
                                     },
                                     {
-                                        "name": "HEXBOARD_HOST",
-                                        "value": "${HEXBOARD_HOST}"
-                                    },
-                                    {
                                         "name": "ACCESS_TOKEN",
                                         "value": "${ACCESS_TOKEN}"
                                     }
@@ -364,19 +360,14 @@
     ],
     "parameters": [
         {
-            "description": "The host URL for the app (port included)",
-            "value": "localhost:1080",
-            "name": "HEXBOARD_HOST"
+            "description": "OpenShift OAuth token (REQUIRED)",
+            "value": "Missing!",
+            "name": "ACCESS_TOKEN"
         },
         {
             "description": "The total number of hexagons (containers) to display in the UI",
-            "value": "xsmall",
+            "value": "small",
             "name": "HEXBOARD_SIZE"
-        },
-        {
-            "description": "OpenShift OAuth token",
-            "value": "Missing (and Required!)",
-            "name": "ACCESS_TOKEN"
         },
         {
             "description": "Generic webhook secret",

--- a/server/api/sketch_controller.js
+++ b/server/api/sketch_controller.js
@@ -151,7 +151,7 @@ var parseSketch = function(req) {
   };
   var stream = parseSketchStream(req);
   hexboard.claimHexagon(sketch);
-  if (sketch.pod && sketch.pod.url) {  // config.get('HEXBOARD_HOST') == ''
+  if (sketch.pod && sketch.pod.url) {  // config.get('PROXY') == ''
     console.log(tag, 'pod.url', sketch.pod.url);
     if (sketch.pod.url.indexOf('/') === 0) {
       sketch.externalUrl = 'http://' + req.get('Host') + sketch.pod.url;

--- a/server/config.js
+++ b/server/config.js
@@ -8,7 +8,7 @@ var autoconfig = function (config_overrides){
   , BASIC_AUTH_USER: process.env.BASIC_AUTH_USER || ''
   , BASIC_AUTH_PASSWORD: process.env.BASIC_AUTH_PASSWORD || ''
   , HEXBOARD_SIZE: process.env.HEXBOARD_SIZE || 'small' // xsmall, small, medium, large, xlarge
-  , HEXBOARD_HOST: process.env.HEXBOARD_HOST || '/'
+  , PROXY: process.env.PROXY || ''
   })
   return config;
 }

--- a/server/hexboard/pod-parser.js
+++ b/server/hexboard/pod-parser.js
@@ -76,7 +76,7 @@ var PodParser = function() {
       } else if (update.object.status.phase === 'Running' && update.object.status.Condition[0].type == 'Ready' && update.object.status.Condition[0].status === 'True') {
         update.data.ip = update.object.status.podIP;
         update.data.port = 8080;
-        update.data.url = config.get('HEXBOARD_HOST') + '/direct/' + update.data.ip + '/';
+        update.data.url = config.get('PROXY') + '/direct/' + update.data.ip + '/';
         console.log(update.data.url)
         update.data.stage = 4;
       } else {

--- a/server/hexboard/pod.js
+++ b/server/hexboard/pod.js
@@ -54,8 +54,7 @@ var environment = {
 function verifyPodAvailable(parsed, timeout) {
   var pod = parsed.data;
   return Rx.Observable.create(function(observer) {
-    //var url = config.get('HEXBOARD_HOST') ? pod.url : 'http://' + pod.ip + ':' + pod.port + '/';
-    var url = pod.url;
+    var url = config.get('PROXY') ? pod.url : 'http://' + pod.ip + ':' + pod.port + '/';
     var options = {
       url: url + 'status'
     , method: 'get'


### PR DESCRIPTION
reverting some changes...

Don't set the `PROXY` config unless you are developing locally.  Set to the hostname of a remotely-hosted hexboard instance.