### PR TITLE
Fix watch URL and Query string

### DIFF
--- a/server/hexboard/pod.js
+++ b/server/hexboard/pod.js
@@ -39,9 +39,10 @@ var environment = {
   , pool: listWatchAgent
   }, optionsBase)
 , watchOptions: _.defaults({
-    url: 'https://' + config.get('OPENSHIFT_SERVER') + '/api/v1/watch/namespaces/' + config.get('NAMESPACE') + '/pods'
+    url: 'https://' + config.get('OPENSHIFT_SERVER') + '/api/v1/namespaces/' + config.get('NAMESPACE') + '/pods'
   , auth: {bearer:  config.get('OAUTH_TOKEN')}
   , pool: listWatchAgent
+  , qs: "watch=true"
   }, optionsBase)
 , state: {first  : true, pods: {}}
 , subjects: _.range(hexboard.layout.count).map(function(index) {


### PR DESCRIPTION
@ryanj The v1 api turned watch into a query string parameter on the object get call, instead of being a separate path parameter.